### PR TITLE
feat: add bypass permission feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 pnpm-lock.yaml
 records/**
 .claude/**
+.augment/**
 
 # Documentation
 CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -47,6 +47,17 @@
           },
           "default": [],
           "description": "Environment variables to set when launching Claude"
+        },
+        "claudix.initialPermissionMode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "acceptEdits",
+            "plan",
+            "bypassPermissions"
+          ],
+          "default": "default",
+          "description": "Default permission mode for new Claude sessions. WARNING: 'bypassPermissions' will allow Claude to run tools and apply edits without asking for confirmation."
         }
       }
     },

--- a/src/services/claude/ClaudeSdkService.ts
+++ b/src/services/claude/ClaudeSdkService.ts
@@ -126,6 +126,7 @@ export class ClaudeSdkService implements IClaudeSdkService {
             model: modelParam,
             permissionMode: permissionModeParam,
             maxThinkingTokens: maxThinkingTokens,
+            allowDangerouslySkipPermissions: true,
 
             // CanUseTool 回调
             canUseTool,
@@ -190,9 +191,6 @@ export class ClaudeSdkService implements IClaudeSdkService {
 
             // CLI 可执行文件路径
             pathToClaudeCodeExecutable: this.getClaudeExecutablePath(),
-
-            // 额外参数
-            extraArgs: {} as Record<string, string | null>,
 
             // 设置源
             // 'user': ~/.claude/settings.json (API 密钥)

--- a/src/services/claude/handlers/handlers.ts
+++ b/src/services/claude/handlers/handlers.ts
@@ -107,6 +107,10 @@ export async function handleInit(
     // 获取 thinking level (默认值)
     const thinkingLevel = 'default_on';
 
+    // 获取初始权限模式（默认 default）
+    const initialPermissionModeSetting = configService.getValue<string>('claudix.initialPermissionMode');
+    const initialPermissionMode: PermissionMode = (initialPermissionModeSetting as PermissionMode) || 'default';
+
     return {
         type: "init_response",
         state: {
@@ -115,7 +119,8 @@ export async function handleInit(
             // authStatus,
             modelSetting,
             platform: process.platform,
-            thinkingLevel
+            thinkingLevel,
+            initialPermissionMode
         }
     };
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -127,6 +127,7 @@ export interface InitResponse {
         modelSetting: string;
         platform: string;
         thinkingLevel?: string;        // Thinking 等级（off | default_on）
+        initialPermissionMode?: PermissionMode;
     };
 }
 

--- a/src/webview/src/components/ModeSelect.vue
+++ b/src/webview/src/components/ModeSelect.vue
@@ -52,6 +52,18 @@
         :index="2"
         @click="(item) => handleModeSelect(item, close)"
       />
+      <DropdownItem
+        :item="{
+          id: 'bypassPermissions',
+          label: 'Bypass',
+          icon: 'codicon-warning text-[14px]!',
+          checked: permissionMode === 'bypassPermissions',
+          type: 'bypass-mode'
+        }"
+        :is-selected="permissionMode === 'bypassPermissions'"
+        :index="3"
+        @click="(item) => handleModeSelect(item, close)"
+      />
     </template>
   </DropdownTrigger>
 </template>
@@ -82,6 +94,8 @@ const selectedModeLabel = computed(() => {
       return 'Agent'
     case 'plan':
       return 'Plan'
+    case 'bypassPermissions':
+      return 'Bypass'
     case 'default':
       return 'Default'
     default:
@@ -96,6 +110,8 @@ const selectedModeIcon = computed(() => {
       return 'codicon-infinity'
     case 'plan':
       return 'codicon-todos'
+    case 'bypassPermissions':
+      return 'codicon-warning'
     case 'default':
       return 'codicon-chat'
     default:

--- a/src/webview/src/core/Session.ts
+++ b/src/webview/src/core/Session.ts
@@ -65,6 +65,7 @@ export class Session {
   private currentConnectionPromise?: Promise<BaseTransport>;
   private lastSentSelection?: SelectionRange;
   private effectCleanup?: () => void;
+  private hasExplicitlySetPermissionMode = false;
 
   readonly connection = signal<BaseTransport | undefined>(undefined);
 
@@ -263,6 +264,15 @@ export class Session {
       this.thinkingLevel(connection.config()?.thinkingLevel || 'default_on');
     }
 
+    const config = connection.config?.();
+    if (
+      config?.initialPermissionMode &&
+      this.permissionMode() === 'default' &&
+      !this.hasExplicitlySetPermissionMode
+    ) {
+      this.permissionMode(config.initialPermissionMode);
+    }
+
     const stream = connection.launchClaude(
       channelId,
       this.sessionId() ?? undefined,
@@ -298,6 +308,7 @@ export class Session {
   }
 
   async setPermissionMode(mode: PermissionMode, applyToConnection = true): Promise<boolean> {
+    this.hasExplicitlySetPermissionMode = true;
     const previous = this.permissionMode();
     this.permissionMode(mode);
 

--- a/src/webview/src/pages/ChatPage.vue
+++ b/src/webview/src/pages/ChatPage.vue
@@ -283,7 +283,7 @@
   const togglePermissionMode = () => {
     const s = session.value;
     if (!s) return;
-    const order: PermissionMode[] = ['default', 'acceptEdits', 'plan'];
+    const order: PermissionMode[] = ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
     const cur = (s.permissionMode.value as PermissionMode) ?? 'default';
     const idx = Math.max(0, order.indexOf(cur));
     const next = order[(idx + 1) % order.length];

--- a/src/webview/src/transport/BaseTransport.ts
+++ b/src/webview/src/transport/BaseTransport.ts
@@ -64,6 +64,7 @@ export abstract class BaseTransport {
       modelSetting: initResponse.state.modelSetting,
       platform: initResponse.state.platform,
       thinkingLevel: initResponse.state.thinkingLevel,
+      initialPermissionMode: initResponse.state.initialPermissionMode,
     } as InitResponse["state"]);
 
     const claudeState = await this.sendRequest<GetClaudeStateResponse>({


### PR DESCRIPTION
## Summary / 摘要

This PR wires a new "Bypass Permission" mode that allows Claude to execute tools and apply edits without requesting user confirmation. 

此 PR 连接了"绕过权限"模式，允许 Claude 在不请求用户确认的情况下执行工具和应用编辑。

---

## Changes / 变更内容

- **Configuration**: Added `claudix.initialPermissionMode` setting to allow users to set their preferred default permission mode
- **Permission Modes**: Extended permission mode options to include `bypassPermissions`
- **UI Updates**: Added "Bypass" mode button with warning icon in the mode selector dropdown
- **Session Management**: Implemented automatic application of initial permission mode for new sessions
- **Service Layer**: Enabled `allowDangerouslySkipPermissions` flag in Claude SDK service
- **Git Ignore**: Added `.augment/` directory to `.gitignore`

- **配置选项**：添加 `claudix.initialPermissionMode` 设置，允许用户设置首选的默认权限模式
- **权限模式**：扩展权限模式选项，包含 `bypassPermissions`
- **UI 更新**：在模式选择下拉菜单中添加带警告图标的"Bypass"模式按钮
- **会话管理**：为新会话实现初始权限模式的自动应用
- **服务层**：在 Claude SDK 服务中启用 `allowDangerouslySkipPermissions` 标志
- **Git 忽略**：将 `.augment/` 目录添加到 `.gitignore`

---

## Modified Files / 修改的文件

- [.gitignore](.gitignore) - Added `.augment/**` to ignore list
- [package.json](package.json) - Added `claudix.initialPermissionMode` configuration
- [src/services/claude/ClaudeSdkService.ts](src/services/claude/ClaudeSdkService.ts) - Enabled dangerous skip permissions flag
- [src/services/claude/handlers/handlers.ts](src/services/claude/handlers/handlers.ts) - Added initial permission mode handling
- [src/shared/messages.ts](src/shared/messages.ts) - Extended `InitResponse` interface
- [src/webview/src/components/ModeSelect.vue](src/webview/src/components/ModeSelect.vue) - Added Bypass mode UI
- [src/webview/src/core/Session.ts](src/webview/src/core/Session.ts) - Implemented initial permission mode logic
- [src/webview/src/pages/ChatPage.vue](src/webview/src/pages/ChatPage.vue) - Added bypass mode to toggle cycle
- [src/webview/src/transport/BaseTransport.ts](src/webview/src/transport/BaseTransport.ts) - Pass through initial permission mode

---

## Usage / 使用方法

1. Open VSCode settings (`Ctrl+,` or `Cmd+,`)
2. Search for "Claudix: Initial Permission Mode"
3. Select your preferred initialization mode:
   - `default`: Ask for permission on each tool use
   - `acceptEdits`: Automatically accept edit operations
   - `plan`: Plan mode for task planning
   - `bypassPermissions`: **⚠️ WARNING** - Skip all permission prompts

Toggle between modes using the mode selector in the chat interface.

1. 打开 VSCode 设置 (`Ctrl+,` 或 `Cmd+,`)
2. 搜索 "Claudix: Initial Permission Mode"
3. 选择你偏好的初始模式：
   - `default`: 每次工具使用时请求权限
   - `acceptEdits`: 自动接受编辑操作
   - `plan`: 任务规划的计划模式
   - `bypassPermissions`: **⚠️ 警告** - 跳过所有权限提示

在聊天界面中使用模式选择器在模式之间切换。

---

## Summary by Sourcery

Enable a new bypass permission feature by adding a configurable initialPermissionMode setting, updating session initialization, service, and transport layers, and enhancing the UI to support a warning-enabled Bypass mode that skips all confirmation prompts

New Features:
- Introduce bypassPermissions mode to skip all permission prompts and automatically execute tool calls and edits
- Add claudix.initialPermissionMode setting to configure and persist the default permission mode for new Claude sessions

Enhancements:
- Automatically apply the configured initial permission mode in new sessions and track manual changes
- Extend init response handling and transport logic to include the initialPermissionMode state
- Update chat UI mode selector and toggle cycle to include a Bypass option with a warning icon
- Enable allowDangerouslySkipPermissions flag in the Claude SDK service

Chores:
- Add .augment/ directory to .gitignore