### PR TITLE
fix: 修复标题过长时遮挡操作按钮的问题

### DIFF
--- a/src/webview/src/pages/ChatPage.vue
+++ b/src/webview/src/pages/ChatPage.vue
@@ -382,6 +382,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    overflow: hidden;
+    flex: 1;
   }
 
   .menu-btn {
@@ -413,8 +415,6 @@
     font-size: 12px;
     font-weight: 600;
     color: var(--vscode-titleBar-activeForeground);
-    /* 限制标题长度，避免溢出 */
-    max-width: 500px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
## 修改内容
- 移除标题的固定最大宽度限制
- 为标题容器添加 flex 布局，使其自适应可用空间
- 避免标题过长时遮挡右侧的操作按钮

## Summary by Sourcery

Prevent long titles from overlapping action buttons

Bug Fixes:
- Fix title overlapping action buttons when title is too long

Enhancements:
- Switch title container to flex layout with overflow hidden and remove its fixed max-width constraint