### PR TITLE
fix: 修复 package 脚本跨平台兼容性问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "typecheck": "tsc --noEmit",
     "typecheck:webview": "vue-tsc -p src/webview/tsconfig.json --noEmit",
     "typecheck:all": "pnpm run typecheck && pnpm run typecheck:webview",
-    "prepackage": "pnpm run build && cp README.md README.md.bak && sed -i '' 's|https://awesome.re/mentioned-badge.svg|assets/mentioned-badge.png|g' README.md",
+    "prepackage": "pnpm run build && node -e \"const fs=require('fs');const c=fs.readFileSync('README.md','utf8');fs.writeFileSync('README.md.bak',c);fs.writeFileSync('README.md',c.replace(/https:\\/\\/awesome\\.re\\/mentioned-badge\\.svg/g,'assets/mentioned-badge.png'));\"",
     "package": "vsce package --no-dependencies",
-    "postpackage": "mv README.md.bak README.md",
+    "postpackage": "node -e \"const fs=require('fs');fs.renameSync('README.md.bak','README.md');\"",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,vue}\" && eslint src --ext ts,tsx,vue --fix"


### PR DESCRIPTION
- 关联 commit b7427fe
- 将 prepackage 中的 sed 命令替换为 Node.js 脚本
- 将 postpackage 中的 mv 命令替换为 fs.renameSync()
- 使用纯 JavaScript 实现，避免了系统命令在不同平台上的差异
- 确保在 Windows、macOS 和 Linux 上都能正常工作


