### PR TITLE
chore: convert shell scripts to Node.js for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "typecheck": "tsc --noEmit",
     "typecheck:webview": "vue-tsc -p src/webview/tsconfig.json --noEmit",
     "typecheck:all": "pnpm run typecheck && pnpm run typecheck:webview",
-    "prepackage": "pnpm run build && cp README.md README.md.bak && sed -i '' 's|https://awesome.re/mentioned-badge.svg|assets/mentioned-badge.png|g' README.md",
+    "prepackage": "node prepackage.mjs",
     "package": "vsce package --no-dependencies",
-    "postpackage": "mv README.md.bak README.md",
+    "postpackage": "node postpackage.mjs",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,vue}\" && eslint src --ext ts,tsx,vue --fix"

--- a/postpackage.mjs
+++ b/postpackage.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const backupPath = path.join(process.cwd(), 'README.md.bak');
+const readmePath = path.join(process.cwd(), 'README.md');
+
+// 恢复 README.md
+if (fs.existsSync(backupPath)) {
+    fs.copyFileSync(backupPath, readmePath);
+    fs.unlinkSync(backupPath);
+    console.log('README.md restored');
+}

--- a/prepackage.mjs
+++ b/prepackage.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+// 备份 README.md
+const readmePath = path.join(process.cwd(), 'README.md');
+const backupPath = path.join(process.cwd(), 'README.md.bak');
+
+if (fs.existsSync(backupPath)) {
+    fs.unlinkSync(backupPath);
+}
+fs.copyFileSync(readmePath, backupPath);
+
+// 替换 README 中的 SVG 链接为 PNG
+let content = fs.readFileSync(readmePath, 'utf8');
+content = content.replaceAll('https://awesome.re/mentioned-badge.svg', 'assets/mentioned-badge.png');
+fs.writeFileSync(readmePath, content);
+
+console.log('README.md prepared for packaging');


### PR DESCRIPTION
convert shell scripts to Node.js for cross-platform compatibility (windows)

## Summary by Sourcery

Replace shell-based packaging scripts with Node.js equivalents to improve cross-platform compatibility for the packaging workflow.

New Features:
- Add a Node.js prepackage script that backs up README.md and rewrites the mentioned badge SVG URL to a PNG asset before packaging.
- Add a Node.js postpackage script that restores README.md from its backup after packaging.

Enhancements:
- Update package.json packaging scripts to invoke the new Node.js pre- and post-package scripts instead of inline shell commands.