### PR TITLE
feat: add YOLO mode (bypassPermissions)

### DIFF
--- a/src/webview/src/components/ModeSelect.vue
+++ b/src/webview/src/components/ModeSelect.vue
@@ -52,6 +52,18 @@
         :index="2"
         @click="(item) => handleModeSelect(item, close)"
       />
+      <DropdownItem
+        :item="{
+          id: 'bypassPermissions',
+          label: 'YOLO',
+          icon: 'codicon-flame text-[14px]!',
+          checked: permissionMode === 'bypassPermissions',
+          type: 'yolo-mode'
+        }"
+        :is-selected="permissionMode === 'bypassPermissions'"
+        :index="3"
+        @click="(item) => handleModeSelect(item, close)"
+      />
     </template>
   </DropdownTrigger>
 </template>
@@ -82,6 +94,8 @@ const selectedModeLabel = computed(() => {
       return 'Agent'
     case 'plan':
       return 'Plan'
+    case 'bypassPermissions':
+      return 'YOLO'
     case 'default':
       return 'Default'
     default:
@@ -96,6 +110,8 @@ const selectedModeIcon = computed(() => {
       return 'codicon-infinity'
     case 'plan':
       return 'codicon-todos'
+    case 'bypassPermissions':
+      return 'codicon-flame'
     case 'default':
       return 'codicon-chat'
     default:

--- a/src/webview/src/pages/ChatPage.vue
+++ b/src/webview/src/pages/ChatPage.vue
@@ -283,7 +283,7 @@
   const togglePermissionMode = () => {
     const s = session.value;
     if (!s) return;
-    const order: PermissionMode[] = ['default', 'acceptEdits', 'plan'];
+    const order: PermissionMode[] = ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
     const cur = (s.permissionMode.value as PermissionMode) ?? 'default';
     const idx = Math.max(0, order.indexOf(cur));
     const next = order[(idx + 1) % order.length];


### PR DESCRIPTION
## Summary
- Add `bypassPermissions` mode to mode dropdown as "YOLO"
- Auto-approves ALL tool executions without prompting
- Uses flame icon to indicate danger

## Changes
- `ModeSelect.vue`: Add 4th dropdown item + computed props for label/icon
- `ChatPage.vue`: Add to Shift+Tab toggle cycle

## Test plan
- [ ] Verify dropdown shows 4 modes (Default, Agent, Plan, YOLO)
- [ ] Verify Shift+Tab cycles through all modes
- [ ] Verify YOLO mode auto-approves commands without prompting

## Summary by Sourcery

Add a new YOLO (bypassPermissions) permission mode to the chat UI and document its design and rollout plan.

New Features:
- Expose a new YOLO mode in the permission mode dropdown that maps to the bypassPermissions behavior and uses a distinct flame icon.
- Include the YOLO mode in the keyboard-based permission mode toggle cycle on the chat page.

Documentation:
- Add design and implementation plan documents describing the YOLO (bypassPermissions) mode, its behavior, and associated trade-offs.