### PR TITLE
feat: add support for multiple chat instances in editor panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
       {
         "command": "claudix.openSettings",
         "title": "Claudix: Open Settings"
+      },
+      {
+        "command": "claudix.openChatInEditor",
+        "title": "Claudix: Open Chat in Editor",
+        "icon": "$(comment-discussion)"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,22 @@ export function activate(context: vscode.ExtensionContext) {
 			})
 		);
 
+		context.subscriptions.push(
+			vscode.commands.registerCommand('claudix.openChatInEditor', () => {
+				instantiationService.invokeFunction(accessorInner => {
+					const webViewServiceInner = accessorInner.get(IWebViewService);
+					const logServiceInner = accessorInner.get(ILogService);
+					try {
+						const instanceId = `chat-${Date.now()}`;
+						webViewServiceInner.openEditorPage('chat', 'Claudix Chat', instanceId);
+						logServiceInner.info(`[Command] Opened chat in editor: ${instanceId}`);
+					} catch (error) {
+						logServiceInner.error('[Command] Failed to open chat in editor', error);
+					}
+				});
+			})
+		);
+
 		logService.info('✓ Claude Agent Service 已连接 Transport');
 		logService.info('✓ WebView Service 已注册为 View Provider');
 		logService.info('✓ Settings 命令已注册');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// Connect WebView messages to Claude Agent Service
 		webViewService.setMessageHandler((message) => {
+			// Update editor panel title if message includes panelTitle and instanceId
+			if (message.panelTitle && message.instanceId) {
+				webViewService.updatePanelTitle(message.instanceId, message.panelTitle);
+			}
 			claudeAgentService.fromClient(message);
 		});
 

--- a/src/services/webViewService.ts
+++ b/src/services/webViewService.ts
@@ -187,6 +187,9 @@ export class WebViewService implements IWebViewService {
 			}
 		);
 
+		// Set panel icon (same as sidebar for consistency)
+		panel.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'resources', 'claude-logo.svg'));
+
 		this.registerWebview(panel.webview, {
 			host: 'editor',
 			page,

--- a/src/services/webViewService.ts
+++ b/src/services/webViewService.ts
@@ -49,6 +49,14 @@ export interface IWebViewService extends vscode.WebviewViewProvider {
 	 * @param instanceId 页面实例 ID，用于区分多标签（不传则默认为 page，实现单例）
 	 */
 	openEditorPage(page: string, title: string, instanceId?: string): void;
+
+	/**
+	 * Update editor panel title (editor panels only)
+	 *
+	 * @param instanceId Panel instance ID
+	 * @param title New title (will be truncated to 40 chars)
+	 */
+	updatePanelTitle(instanceId: string, title: string): void;
 }
 
 /**
@@ -208,6 +216,21 @@ export class WebViewService implements IWebViewService {
 		);
 
 		this.editorPanels.set(key, panel);
+	}
+
+	/**
+	 * Update editor panel title
+	 */
+	updatePanelTitle(instanceId: string, title: string): void {
+		const panel = this.editorPanels.get(instanceId);
+		if (!panel) {
+			return;
+		}
+
+		// Clean and truncate title
+		const cleaned = title.replace(/\s+/g, ' ').trim();
+		const truncated = cleaned.length > 40 ? cleaned.slice(0, 40) + '…' : cleaned;
+		panel.title = truncated || 'Claudix Chat';
 	}
 
 	/**

--- a/src/services/webViewService.ts
+++ b/src/services/webViewService.ts
@@ -109,8 +109,8 @@ export class WebViewService implements IWebViewService {
 	 * 广播消息到所有已注册的 WebView
 	 */
 	postMessage(message: any): void {
-		// 目前 ClaudeAgentService 只需要与侧边栏聊天视图通信
-		// 因此这里只向 host === 'sidebar' 且 page === 'chat' 的 WebView 发送消息
+		// 向所有 page === 'chat' 的 WebView 发送消息（包括侧边栏和编辑器面板）
+		// 每个 WebView 会根据 channelId 过滤自己需要的消息
 		if (this.webviews.size === 0) {
 			this.logService.warn('[WebViewService] 当前没有可用的 WebView 实例，消息将被丢弃');
 			return;
@@ -125,7 +125,7 @@ export class WebViewService implements IWebViewService {
 
 		for (const webview of this.webviews) {
 			const config = this.webviewConfigs.get(webview);
-			if (!config || config.host !== 'sidebar' || (config.page && config.page !== 'chat')) {
+			if (!config || config.page !== 'chat') {
 				continue;
 			}
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -49,6 +49,8 @@ export interface IOMessage extends BaseMessage {
     channelId: string;
     message: SDKMessage | SDKUserMessage;  // SDK 消息类型
     done: boolean;                         // 是否为流的最后一条
+    panelTitle?: string;                   // Editor panel title (editor host only)
+    instanceId?: string;                   // Panel instance ID (editor host only)
 }
 
 /**

--- a/src/webview/src/core/Session.ts
+++ b/src/webview/src/core/Session.ts
@@ -232,7 +232,17 @@ export class Session {
     try {
       const channelId = this.claudeChannelId();
       if (!channelId) throw new Error('No active channel');
-      connection.sendInput(channelId, userMessage, false);
+
+      // Update editor panel title with user input
+      const bootstrap = window.CLAUDIX_BOOTSTRAP;
+      const isEditor = bootstrap?.host === 'editor' && bootstrap?.id;
+      connection.sendInput(
+        channelId,
+        userMessage,
+        false,
+        isEditor ? input : undefined,
+        isEditor ? bootstrap.id : undefined
+      );
     } catch (error) {
       this.busy(false);
       throw error;

--- a/src/webview/src/main.ts
+++ b/src/webview/src/main.ts
@@ -15,6 +15,7 @@ declare global {
     CLAUDIX_BOOTSTRAP?: {
       host?: 'sidebar' | 'editor';
       page?: string;
+      id?: string;
     };
   }
 }

--- a/src/webview/src/styles/claude-theme.css
+++ b/src/webview/src/styles/claude-theme.css
@@ -77,6 +77,7 @@ html {
 body {
   padding: 0 !important;
   margin: 0 !important;
+  background: var(--vscode-sideBar-background);
 }
 
 /* Light 主题调整 */

--- a/src/webview/src/transport/BaseTransport.ts
+++ b/src/webview/src/transport/BaseTransport.ts
@@ -95,8 +95,8 @@ export abstract class BaseTransport {
     return queue;
   }
 
-  sendInput(channelId: string, message: any, done: boolean): void {
-    this.send({ type: "io_message", channelId, message, done });
+  sendInput(channelId: string, message: any, done: boolean, panelTitle?: string, instanceId?: string): void {
+    this.send({ type: "io_message", channelId, message, done, panelTitle, instanceId });
   }
 
   interruptClaude(channelId: string): void {


### PR DESCRIPTION
## Summary

Enable users to open multiple independent Claudix chat sessions in VSCode editor panels alongside the existing sidebar view.

- Add `claudix.openChatInEditor` command to open chat in editor panel
- Update `postMessage()` to broadcast to all chat webviews (sidebar + editor)
- Each webview filters messages by its own channelId

## How it works

The backend already supports multiple channels via `channelId` routing. The frontend `BaseTransport` filters messages by channelId via its `streams` Map and `outstandingRequests` Map, ensuring messages reach the correct instance.

**Key change:** Removed `host === 'sidebar'` filter from `postMessage()`, allowing editor panels with `page === 'chat'` to receive messages.

## Usage

1. Open Command Palette (Cmd+Shift+P)
2. Run "Claudix: Open Chat in Editor"
3. New chat panel opens in editor area
4. Each panel works independently with its own session

## Test plan

- [ ] Open chat in editor via command palette
- [ ] Verify messages work in editor panel
- [ ] Open multiple editor panels, verify independent sessions
- [ ] Verify sidebar chat still works
- [ ] Close panels, verify no errors

## Summary by Sourcery

Add support for opening independent Claudix chat sessions in VS Code editor panels and broadcast chat messages to all chat webviews.

New Features:
- Introduce a `claudix.openChatInEditor` command to open a Claudix chat session in an editor panel with its own instance ID.

Enhancements:
- Update the WebView message broadcasting logic to send chat messages to all chat pages (sidebar and editor panels) while relying on per-webview channel filtering.
- Expose the new editor chat command in the extension contributions with a command palette entry and icon.